### PR TITLE
feat(removal): delay automated eForm removal to avoid orphaning mid-inspection devices

### DIFF
--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn.Test/DbTestFixture.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn.Test/DbTestFixture.cs
@@ -58,6 +58,8 @@ namespace TrashInspection.Pn.Test
         {
             List<string> modelNames = new List<string>
             {
+                "TrashInspectionCaseVersions",
+                "TrashInspectionCases",
                 "TrashInspectionVersions",
                 "TrashInspections",
                 "TrashInspectionSettings",

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn.Test/PendingInspectionRemovalTest.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn.Test/PendingInspectionRemovalTest.cs
@@ -1,0 +1,151 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2019 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormTrashInspectionBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+using TrashInspection.Pn.Infrastructure.Helpers;
+
+namespace TrashInspection.Pn.Test
+{
+    [TestFixture]
+    public class PendingInspectionRemovalTest : DbTestFixture
+    {
+        // Fixed "now" so the timing comparisons are deterministic.
+        private static readonly DateTime UtcNow = new DateTime(2026, 06, 16, 12, 00, 00, DateTimeKind.Utc);
+        private const int DelaySeconds = 1800; // 30 min
+
+        protected override void DoSetup()
+        {
+            // TrashInspection and TrashInspectionCase carry non-nullable FK columns
+            // (Fraction/Segment/Installation on the inspection, Segment on the case). Seed one
+            // minimal parent row (Id=1) for each so Create() does not trip the FK constraints.
+            DbContext.Database.ExecuteSqlRaw(
+                "INSERT INTO `Segments` (`Id`,`CreatedAt`,`CreatedByUserId`,`UpdatedByUserId`,`Version`,`SdkFolderId`) " +
+                "VALUES (1, UTC_TIMESTAMP(), 1, 1, 1, 1)");
+            DbContext.Database.ExecuteSqlRaw(
+                "INSERT INTO `Fractions` (`Id`,`CreatedAt`,`CreatedByUserId`,`UpdatedByUserId`,`Version`,`eFormId`,`eFormIdExtendedInspection`) " +
+                "VALUES (1, UTC_TIMESTAMP(), 1, 1, 1, 1, 0)");
+            DbContext.Database.ExecuteSqlRaw(
+                "INSERT INTO `Installations` (`Id`,`CreatedAt`,`CreatedByUserId`,`UpdatedByUserId`,`Version`) " +
+                "VALUES (1, UTC_TIMESTAMP(), 1, 1, 1)");
+        }
+
+        [Test]
+        public async Task GetCasesDueForRemoval_ReturnsOnlyDueLiveCases()
+        {
+            // A: deferred-pending, older than the delay, live case => DUE (the only one expected).
+            var caseA = await SeedScenario(
+                inspectionDone: true,
+                inspectionWorkflowState: Constants.WorkflowStates.Created,
+                inspectionUpdatedAt: UtcNow.AddMinutes(-31),
+                caseWorkflowState: Constants.WorkflowStates.Created);
+
+            // B: deferred-pending but still inside the delay window => NOT due.
+            await SeedScenario(
+                inspectionDone: true,
+                inspectionWorkflowState: Constants.WorkflowStates.Created,
+                inspectionUpdatedAt: UtcNow.AddMinutes(-5),
+                caseWorkflowState: Constants.WorkflowStates.Created);
+
+            // C: not flagged for deferred removal (InspectionDone == false) => NOT returned.
+            await SeedScenario(
+                inspectionDone: false,
+                inspectionWorkflowState: Constants.WorkflowStates.Created,
+                inspectionUpdatedAt: UtcNow.AddMinutes(-60),
+                caseWorkflowState: Constants.WorkflowStates.Created);
+
+            // D: deferred-pending, old, but the case is already removed => NOT returned.
+            await SeedScenario(
+                inspectionDone: true,
+                inspectionWorkflowState: Constants.WorkflowStates.Created,
+                inspectionUpdatedAt: UtcNow.AddMinutes(-60),
+                caseWorkflowState: Constants.WorkflowStates.Removed);
+
+            // E: old + InspectionDone but the inspection itself was admin-deleted (Removed) => NOT returned.
+            await SeedScenario(
+                inspectionDone: true,
+                inspectionWorkflowState: Constants.WorkflowStates.Removed,
+                inspectionUpdatedAt: UtcNow.AddMinutes(-60),
+                caseWorkflowState: Constants.WorkflowStates.Created);
+
+            List<TrashInspectionCase> due =
+                await PendingInspectionRemoval.GetCasesDueForRemoval(DbContext, DelaySeconds, UtcNow);
+
+            Assert.That(due.Count, Is.EqualTo(1));
+            Assert.That(due.Single().Id, Is.EqualTo(caseA.Id));
+        }
+
+        /// <summary>
+        /// Seeds one TrashInspection + one TrashInspectionCase with explicit InspectionDone /
+        /// WorkflowState / UpdatedAt values. We persist via Create (which stamps UpdatedAt = now),
+        /// then override the audit/state fields directly and SaveChanges so the timing is
+        /// deterministic rather than dependent on wall-clock.
+        /// </summary>
+        private async Task<TrashInspectionCase> SeedScenario(
+            bool inspectionDone,
+            string inspectionWorkflowState,
+            DateTime inspectionUpdatedAt,
+            string caseWorkflowState)
+        {
+            var inspection = new Microting.eFormTrashInspectionBase.Infrastructure.Data.Entities.TrashInspection
+            {
+                Status = 0,
+                Date = UtcNow,
+                Time = UtcNow,
+                WeighingNumber = Guid.NewGuid().ToString("N"),
+                FractionId = 1,
+                SegmentId = 1,
+                InstallationId = 1
+            };
+            await inspection.Create(DbContext);
+
+            var trashCase = new TrashInspectionCase
+            {
+                TrashInspectionId = inspection.Id,
+                SdkCaseId = "1",
+                SdkSiteId = 1,
+                Status = 0,
+                SegmentId = 1
+            };
+            await trashCase.Create(DbContext);
+
+            // Override the state/timing fields deterministically and persist without re-stamping.
+            inspection.InspectionDone = inspectionDone;
+            inspection.WorkflowState = inspectionWorkflowState;
+            inspection.UpdatedAt = inspectionUpdatedAt;
+
+            trashCase.WorkflowState = caseWorkflowState;
+
+            await DbContext.SaveChangesAsync();
+
+            return trashCase;
+        }
+    }
+}

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/EformTrashInspectionPlugin.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/EformTrashInspectionPlugin.cs
@@ -102,6 +102,16 @@ namespace TrashInspection.Pn
                 var caseCreatedHandler = sp.GetRequiredService<TrashInspectionCaseCreatedHandler>();
                 return new TrashInspectionReceivedHandler(core, new DbContextHelper(_connectionString), caseCreatedHandler);
             });
+
+            // Background worker that performs the device-side eForm removal that the external /
+            // automated weighing-system delete intentionally defers (see TrashInspectionDeleteHandler).
+            // _connectionString is captured here and is set in ConfigureDbContext, which runs before
+            // the hosted service is started, mirroring the handler factory lambdas above.
+            services.AddHostedService(sp =>
+            {
+                var coreHelper = sp.GetRequiredService<IEFormCoreService>();
+                return new PendingInspectionRemovalWorker(_connectionString, coreHelper);
+            });
         }
 
         public void AddPluginConfig(IConfigurationBuilder builder, string connectionString)

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Handlers/TrashInspectionDeleteHandler.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Handlers/TrashInspectionDeleteHandler.cs
@@ -54,28 +54,51 @@ namespace TrashInspection.Pn.Handlers
             {
                 TrashInspectionModel createModel = message.TrashInspectionModel;
 
-                List<TrashInspectionCase> trashInspectionCases = _dbContext.TrashInspectionCases
-                    .Where(x => x.TrashInspectionId == createModel.Id).ToList();
-
-                foreach (TrashInspectionCase trashInspectionCase in trashInspectionCases)
-                {
-                    bool result = await _core.CaseDelete(int.Parse(trashInspectionCase.SdkCaseId));
-                    if (result)
-                    {
-                        await trashInspectionCase.Delete(_dbContext);
-                    }
-
-                }
-
                 Microting.eFormTrashInspectionBase.Infrastructure.Data.Entities.TrashInspection trashInspection = await
                     _dbContext.TrashInspections.SingleAsync(x => x.Id == createModel.Id);
 
-                trashInspection.InspectionDone = true;
-                await trashInspection.Update(_dbContext);
-
                 if (message.ShouldDelete)
                 {
+                    // Admin-initiated delete (Delete(int id)): remove immediately, as before.
+                    // The user explicitly asked to delete, so cutting off any device-side
+                    // eForm is the intended behavior here.
+                    List<TrashInspectionCase> trashInspectionCases = _dbContext.TrashInspectionCases
+                        .Where(x => x.TrashInspectionId == createModel.Id).ToList();
+
+                    foreach (TrashInspectionCase trashInspectionCase in trashInspectionCases)
+                    {
+                        // Guard against a malformed SdkCaseId so one bad row can't throw and
+                        // leave the inspection half-deleted (mirrors PendingInspectionRemovalWorker).
+                        if (!int.TryParse(trashInspectionCase.SdkCaseId, out int sdkCaseId))
+                        {
+                            continue;
+                        }
+
+                        bool result = await _core.CaseDelete(sdkCaseId);
+                        if (result)
+                        {
+                            await trashInspectionCase.Delete(_dbContext);
+                        }
+                    }
+
+                    trashInspection.InspectionDone = true;
+                    await trashInspection.Update(_dbContext);
+
                     await trashInspection.Delete(_dbContext);
+                }
+                else
+                {
+                    // External/automated delete (Delete(string weighingNumber, token) from the
+                    // weighing system): DEFER the device-side eForm removal instead of firing it
+                    // immediately. Calling _core.CaseDelete here pushes the device sync at once and
+                    // would orphan a worker who is still filling in the inspection on their device.
+                    //
+                    // We only mark the inspection as InspectionDone and stamp UpdatedAt = now (via
+                    // Update). PendingInspectionRemovalWorker later picks up inspections whose
+                    // UpdatedAt is older than the configured delay and performs the CaseDelete then.
+                    // The cases are intentionally left untouched (WorkflowState stays "Created").
+                    trashInspection.InspectionDone = true;
+                    await trashInspection.Update(_dbContext);
                 }
             }
             catch (Exception exception)

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Data/Seed/Data/TrashInspectionConfigurationSeedData.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Data/Seed/Data/TrashInspectionConfigurationSeedData.cs
@@ -96,6 +96,11 @@ namespace TrashInspection.Pn.Infrastructure.Data.Seed.Data
                 Name = "TrashInspectionBaseSettings:UtcAdjustment",
                 Value = "false"
             },
+            new PluginConfigurationValue
+            {
+                Name = "TrashInspectionBaseSettings:InspectionRemovalDelaySeconds",
+                Value = "1800"
+            },
         };
     }
 }

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Helpers/PendingInspectionRemoval.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Helpers/PendingInspectionRemoval.cs
@@ -1,0 +1,65 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2019 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormTrashInspectionBase.Infrastructure.Data;
+using Microting.eFormTrashInspectionBase.Infrastructure.Data.Entities;
+
+namespace TrashInspection.Pn.Infrastructure.Helpers
+{
+    /// <summary>
+    /// Pure, testable selection logic for the deferred device-side eForm removal that is
+    /// triggered by the external/automated weighing-system delete. The matching delete handler
+    /// only marks the inspection as InspectionDone and stamps UpdatedAt; this query finds the
+    /// cases whose deferral window has elapsed so the worker can remove them.
+    /// </summary>
+    public static class PendingInspectionRemoval
+    {
+        /// <summary>
+        /// Returns the still-live <see cref="TrashInspectionCase"/> rows that belong to an
+        /// inspection which was flagged for deferred removal (InspectionDone == true) more than
+        /// <paramref name="delaySeconds"/> ago and has not itself been removed (e.g. by an admin
+        /// delete).
+        /// </summary>
+        public static async Task<List<TrashInspectionCase>> GetCasesDueForRemoval(
+            TrashInspectionPnDbContext db, int delaySeconds, DateTime utcNow)
+        {
+            DateTime cutoff = utcNow.AddSeconds(-delaySeconds);
+
+            return await db.TrashInspectionCases
+                .Where(c => c.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(c => db.TrashInspections.Any(ti =>
+                    ti.Id == c.TrashInspectionId
+                    && ti.InspectionDone
+                    && ti.WorkflowState != Constants.WorkflowStates.Removed
+                    && ti.UpdatedAt < cutoff))
+                .ToListAsync();
+        }
+    }
+}

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Models/Trash-Inspections/TrashInspectionBaseSettings.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Infrastructure/Models/Trash-Inspections/TrashInspectionBaseSettings.cs
@@ -52,6 +52,11 @@ namespace TrashInspection.Pn.Infrastructure.Models
         public int ExtendedInspectioneFormId { get; set; }
 
         public bool UtcAdjustment { get; set; }
+
+        // Delay (in seconds) before the device-side eForm removal triggered by the external /
+        // automated weighing-system delete is actually performed. Defaults to 1800 (30 min) when
+        // unset/0. See PendingInspectionRemovalWorker.
+        public int InspectionRemovalDelaySeconds { get; set; }
     }
 
     public class TrashInspectionBaseToken

--- a/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Services/PendingInspectionRemovalWorker.cs
+++ b/eFormAPI/Plugins/TrashInspection.Pn/TrashInspection.Pn/Services/PendingInspectionRemovalWorker.cs
@@ -1,0 +1,145 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2019 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using eFormCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormTrashInspectionBase.Infrastructure.Data;
+using TrashInspection.Pn.Infrastructure.Helpers;
+
+namespace TrashInspection.Pn.Services
+{
+    /// <summary>
+    /// Background worker that performs the device-side eForm removal deferred by the external /
+    /// automated weighing-system delete (see TrashInspectionDeleteHandler, ShouldDelete == false).
+    ///
+    /// The external delete only marks the inspection InspectionDone and stamps UpdatedAt = now.
+    /// This worker periodically picks up inspections whose UpdatedAt is older than the configured
+    /// delay (default 1800s = 30 min) and only then removes their device-side cases, so a worker
+    /// who is still filling in the inspection on their device isn't cut off immediately.
+    /// </summary>
+    public class PendingInspectionRemovalWorker : BackgroundService
+    {
+        private const int DefaultDelaySeconds = 1800;
+        private const int PollIntervalSeconds = 60;
+        private const string DelaySettingName = "TrashInspectionBaseSettings:InspectionRemovalDelaySeconds";
+
+        private readonly string _connectionString;
+        private readonly IEFormCoreService _coreHelper;
+
+        public PendingInspectionRemovalWorker(string connectionString, IEFormCoreService coreHelper)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            _connectionString = connectionString;
+            _coreHelper = coreHelper;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await RunCycle();
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine($"[PendingInspectionRemovalWorker] cycle failed: {exception.Message}");
+                }
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(PollIntervalSeconds), stoppingToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    // Shutdown requested.
+                }
+            }
+        }
+
+        private async Task RunCycle()
+        {
+            TrashInspectionPnDbContext db = new DbContextHelper(_connectionString).GetDbContext();
+            await using (db)
+            {
+                int delaySeconds = await GetDelaySeconds(db);
+                Core core = await _coreHelper.GetCore();
+
+                var dueCases = await PendingInspectionRemoval.GetCasesDueForRemoval(
+                    db, delaySeconds, DateTime.UtcNow);
+
+                int removed = 0;
+                foreach (var trashInspectionCase in dueCases)
+                {
+                    // Per-case isolation: a single bad SdkCaseId or a failing CaseDelete must not
+                    // abandon the rest of the batch (the worker recurs every 60s, so a stuck batch
+                    // would permanently stall every due case that follows the bad row).
+                    try
+                    {
+                        if (!int.TryParse(trashInspectionCase.SdkCaseId, out int sdkCaseId))
+                        {
+                            Console.WriteLine($"[PendingInspectionRemovalWorker] invalid SdkCaseId " +
+                                $"'{trashInspectionCase.SdkCaseId}' on case {trashInspectionCase.Id}, skipping");
+                            continue;
+                        }
+
+                        if (await core.CaseDelete(sdkCaseId))
+                        {
+                            await trashInspectionCase.Delete(db);
+                            removed++;
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        Console.WriteLine($"[PendingInspectionRemovalWorker] failed to remove case " +
+                            $"{trashInspectionCase.Id}: {exception.Message}");
+                    }
+                }
+
+                if (removed > 0)
+                {
+                    Console.WriteLine($"[PendingInspectionRemovalWorker] removed {removed} deferred case(s)");
+                }
+            }
+        }
+
+        private static async Task<int> GetDelaySeconds(TrashInspectionPnDbContext db)
+        {
+            string value = (await db.PluginConfigurationValues
+                .SingleOrDefaultAsync(x => x.Name == DelaySettingName))?.Value;
+
+            return int.TryParse(value, out int parsed) && parsed > 0 ? parsed : DefaultDelaySeconds;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The automated external delete (`DELETE /api/trash-inspection-pn/inspection-results/{weighingNumber}`, called by the weighing system) removed the deployed eForm from devices **immediately** via `_core.CaseDelete(...)` inside the request (`TrashInspectionDeleteHandler`).

For customers that churn inspections fast, a device that is syncing mid-inspection has the schedule pulled out from under a worker who is still filling it in. On the legacy mobile app this leaves an orphaned/broken state — the worker's checklist references a schedule/checklist that no longer exists locally, and saving crashes (`Null check operator used on a null value` / `Bad state: No element`). Customers that don't remove eForms so quickly never hit this.

## Change

Defer the device-side removal for the **automated/external** delete path:

- `TrashInspectionDeleteHandler` (`ShouldDelete == false`) now only marks the inspection `InspectionDone = true` and stamps `UpdatedAt = now` — it no longer calls `CaseDelete`.
- A new `PendingInspectionRemovalWorker` (`BackgroundService`, polls every 60s) picks up inspections whose `UpdatedAt` is older than a configurable delay and runs `CaseDelete` then soft-deletes the case.
- The **admin** delete (`Delete(int id)`, `ShouldDelete == true`) keeps immediate behavior.
- Delay is configurable via `TrashInspectionBaseSettings:InspectionRemovalDelaySeconds`, **default 1800s (30 min)**.

Selection logic is extracted into `PendingInspectionRemoval.GetCasesDueForRemoval(...)` for testability. No base/NuGet or DB schema change — it reuses the existing `InspectionDone`, `UpdatedAt`, and `WorkflowState` fields.

## Notes / safety

- `InspectionDone` is set only by the delete handler; there is no server-side completion handler (Rebus is disabled), so nothing else trips the worker.
- The poller filters `WorkflowState != "Removed"` on both case and parent inspection, so admin-deleted inspections and already-removed cases are never re-processed.
- Soft-delete only (`PnBase.Delete`), never hard delete. Per-case `try/catch` + `int.TryParse` so one bad row can't stall the batch.

## Testing

- `dotnet build` succeeds (0 warnings / 0 errors).
- New NUnit test (`PendingInspectionRemovalTest`) covers the boundary scenarios (due / within-delay / not-done / already-removed case / admin-deleted inspection) — only the genuinely-due case is selected.
- The selection query was additionally verified against a real MariaDB instance with the same scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
